### PR TITLE
fix: encoding miss

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,8 +15,7 @@
     "charset": "^1.0.1",
     "firebase-admin": "~6.3.0",
     "firebase-functions": "^2.1.0",
-    "iconv-lite": "^0.4.24",
-    "jschardet": "^1.6.0"
+    "iconv-lite": "^0.4.24"
   },
   "devDependencies": {
     "@types/charset": "^1.0.1",

--- a/functions/src/fetcher.ts
+++ b/functions/src/fetcher.ts
@@ -1,16 +1,11 @@
 import axios, { AxiosResponse } from 'axios';
 import * as iconv from 'iconv-lite';
-import * as jschardet from 'jschardet';
 const charset = require('charset');
 
 export async function fetch(url: string): Promise<string> {
   const res: AxiosResponse<Buffer> = await axios.get(url, {      
      responseType: 'arraybuffer',
   });
-  let encoding: string = charset(res.headers);
-  if (!encoding) {
-    const text = res.data.toString('utf8');
-    encoding = jschardet.detect(text).encoding.toLowerCase();;
-  }
-  return iconv.decode(res.data, encoding);
+  const encoding: string = charset(res.headers);
+  return encoding ? iconv.decode(res.data, encoding) : res.data.toString('utf8');
 }


### PR DESCRIPTION
レスポンスヘッダに"encoding"がないブログがasciiでエンコードされてしまっていたので修正