### PR TITLE
Fixed daily report mail using same UUID

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import { flatten } from 'lodash';
 import { auth, firestore } from 'firebase-admin';
-import * as uuidv1 from 'uuid/v1';
+import * as uuidv4 from 'uuid/v4';
 import { fetchText } from './fetcher';
 import { sendWelcomeMail as sendWelcomeMailAction } from './send-welcome-mail';
 import { crowlAndSendMail } from './send-daily-report-mail';
@@ -73,7 +73,7 @@ export const dailyReportMail = functions
 
     const topic = pubsub.topic('send-report-mail');
     for (const [uid, email, blogURL] of uidBlogIds) {
-      const uuid = uuidv1();
+      const uuid = uuidv4();
       const message: MailMessage = { email, uid, blogURL, uuid, forceSend: false };
       await topic.publish(Buffer.from(JSON.stringify(message)));
       console.log(`${uid}, ${blogURL}`);
@@ -101,7 +101,7 @@ export const sendTestReportMail = functions.region('asia-northeast1').https.onCa
   }
   const user = await auth().getUser(context.auth.uid);
   const { email, uid } = user;
-  const uuid = uuidv1(); // dummy
+  const uuid = uuidv4(); // dummy
   const topic = pubsub.topic('send-report-mail');
   const message: MailMessage = { email, uid, blogURL, uuid, forceSend: true };
   await topic.publish(Buffer.from(JSON.stringify(message)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6851,6 +6851,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
   integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stdin@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"


### PR DESCRIPTION
- レポートメールの送信時にCloud Functionsの1回以上起動による再送を防止するため、UUIDを使ってロックを掛けていた
- `uuid/v1` を使っていたが、同じインスタンス、同じ時間で生成したUUIDが同じものになっていた
- `uuid/v4`を使うことでランダムにする