### PR TITLE
Fixed feched count error conditon

### DIFF
--- a/functions/src/send-daily-report-mail.ts
+++ b/functions/src/send-daily-report-mail.ts
@@ -153,9 +153,10 @@ function createCount(
   const prevCount =
     (itemEntitry && itemEntitry.counts && itemEntitry.counts[countType] && itemEntitry.counts[countType].count) || 0;
   const link = toServiceURL(countType, itemResponse.url);
+  const updatedCount = todayCount ? todayCount - (yesterDayCount || prevCount) : 0;
   return {
     count: todayCount || prevCount,
-    updatedCount: todayCount - (yesterDayCount || prevCount),
+    updatedCount,
     type: countType,
     link,
   };


### PR DESCRIPTION
- デイリーレポートメールでシェア数の集計に1つでも失敗していると更新されたシェア数合計が0になってしまっていた
- メールが飛んでいないユーザーが多数いたので修正