### PR TITLE
Remove chrome 41 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "typescript": "^3.4.5"
   },
   "browserslist": [
-    "defaults",
-    "chrome >= 41"
+    "defaults"
   ],
   "prettier": {
     "semi": true,

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,6 @@
     <meta property="fb:app_id" content="385481141526705" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@ninjinkun" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.2.5/polyfill.min.js"></script>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
Google BotがアップデートしてChromium 74相当になったらしいので、Chrome 41サポートを削除する