### PR TITLE
refactor: use "as const" instead of "as typeof"

### DIFF
--- a/src/redux/actions/add-blog-action.ts
+++ b/src/redux/actions/add-blog-action.ts
@@ -9,71 +9,71 @@ import { BlogResponse, FeedResponse } from '../../models/responses';
 import { AppState } from '../states/app-state';
 import { currenUserOronAuthStateChanged } from './user-action';
 
-export const FETCH_BLOG_REQUEST = 'addblog/FETCH_BLOG_REQUEST';
+export const FETCH_BLOG_REQUEST = 'addblog/FETCH_BLOG_REQUEST' as const;
 function addBlogFetchBlogRequest() {
   return {
-    type: FETCH_BLOG_REQUEST as typeof FETCH_BLOG_REQUEST,
+    type: FETCH_BLOG_REQUEST,
   };
 }
 
-export const FETCH_BLOG_RESPONSE = 'addblog/FETCH_BLOG_RESPONSE';
+export const FETCH_BLOG_RESPONSE = 'addblog/FETCH_BLOG_RESPONSE' as const;
 function addBlogFetchBlogResponse(blog: BlogResponse) {
   return {
-    type: FETCH_BLOG_RESPONSE as typeof FETCH_BLOG_RESPONSE,
+    type: FETCH_BLOG_RESPONSE,
     blog,
   };
 }
 
-export const FETCH_FEED_REQUEST = 'addblog/FETCH_FEED_REQUEST';
+export const FETCH_FEED_REQUEST = 'addblog/FETCH_FEED_REQUEST' as const;
 function addBlogFetchFeedRequest() {
   return {
-    type: FETCH_FEED_REQUEST as typeof FETCH_FEED_REQUEST,
+    type: FETCH_FEED_REQUEST,
   };
 }
 
-export const FETCH_FEED_RESPONSE = 'addblog/FETCH_FEED_RESPONSE';
+export const FETCH_FEED_RESPONSE = 'addblog/FETCH_FEED_RESPONSE' as const;
 function addBlogFetchFeedResponse(feed: FeedResponse) {
   return {
-    type: FETCH_FEED_RESPONSE as typeof FETCH_FEED_RESPONSE,
+    type: FETCH_FEED_RESPONSE,
     feed,
   };
 }
 
-export const FETCH_FEED_ERROR = 'addblog/FETCH_FEED_ERROR';
+export const FETCH_FEED_ERROR = 'addblog/FETCH_FEED_ERROR' as const;
 export function addBlogFetchFeedError(error: Error) {
   return {
-    type: FETCH_FEED_ERROR as typeof FETCH_FEED_ERROR,
+    type: FETCH_FEED_ERROR,
     error,
   };
 }
 
-export const FIREBASE_ADD_BLOG_REQUEST = 'addblog/FIREBASE_SAVE_REQUEST';
+export const FIREBASE_ADD_BLOG_REQUEST = 'addblog/FIREBASE_SAVE_REQUEST' as const;
 function addBlogFirebaseSaveRequest() {
   return {
-    type: FIREBASE_ADD_BLOG_REQUEST as typeof FIREBASE_ADD_BLOG_REQUEST,
+    type: FIREBASE_ADD_BLOG_REQUEST,
   };
 }
 
-export const FIREBASE_ADD_BLOG_RESPONSE = 'addblog/FIREBASE_SAVE_RESPONSE';
+export const FIREBASE_ADD_BLOG_RESPONSE = 'addblog/FIREBASE_SAVE_RESPONSE' as const;
 export function addBlogFirebaseSaveResponse(response: BlogResponse) {
   return {
-    type: FIREBASE_ADD_BLOG_RESPONSE as typeof FIREBASE_ADD_BLOG_RESPONSE,
+    type: FIREBASE_ADD_BLOG_RESPONSE,
     response,
   };
 }
 
-export const FIREBASE_ADD_BLOG_ERROR = 'addblog/FIREBASE_SAVE_ERROR';
+export const FIREBASE_ADD_BLOG_ERROR = 'addblog/FIREBASE_SAVE_ERROR' as const;
 export function addBlogFirebaseSaveError(error: Error) {
   return {
-    type: FIREBASE_ADD_BLOG_ERROR as typeof FIREBASE_ADD_BLOG_ERROR,
+    type: FIREBASE_ADD_BLOG_ERROR,
     error,
   };
 }
 
-export const ADD_BLOG_INITIALIZE = 'addblog/INITIALIZE';
+export const ADD_BLOG_INITIALIZE = 'addblog/INITIALIZE' as const;
 export function addBlogInitialize() {
   return {
-    type: ADD_BLOG_INITIALIZE as typeof ADD_BLOG_INITIALIZE,
+    type: ADD_BLOG_INITIALIZE,
   };
 }
 

--- a/src/redux/actions/blog-action.ts
+++ b/src/redux/actions/blog-action.ts
@@ -4,25 +4,25 @@ import { findAllBlogs } from '../../models/repositories/blog-repository';
 import { AppState } from '../states/app-state';
 import { currenUserOronAuthStateChanged } from './user-action';
 
-export const FIREBASE_BLOGS_REQUEST = 'blog/FIREBASE_REQUEST';
+export const FIREBASE_BLOGS_REQUEST = 'blog/FIREBASE_REQUEST' as const;
 export function blogFirebaseRequest() {
   return {
-    type: FIREBASE_BLOGS_REQUEST as typeof FIREBASE_BLOGS_REQUEST,
+    type: FIREBASE_BLOGS_REQUEST,
   };
 }
 
-export const FIREBASE_BLOGS_RESPONSE = 'blog/FIREBASE_RESPONSE';
+export const FIREBASE_BLOGS_RESPONSE = 'blog/FIREBASE_RESPONSE' as const;
 export function blogFirebaseResponse(blogs: BlogEntity[]) {
   return {
-    type: FIREBASE_BLOGS_RESPONSE as typeof FIREBASE_BLOGS_RESPONSE,
+    type: FIREBASE_BLOGS_RESPONSE,
     blogs,
   };
 }
 
-export const FIREBASE_BLOGS_ERROR = 'blog/FIREBASE_ERROR';
+export const FIREBASE_BLOGS_ERROR = 'blog/FIREBASE_ERROR' as const;
 export function blogFirebaseError(error: Error) {
   return {
-    type: FIREBASE_BLOGS_ERROR as typeof FIREBASE_BLOGS_ERROR,
+    type: FIREBASE_BLOGS_ERROR,
     error,
   };
 }

--- a/src/redux/actions/delete-blog-action.ts
+++ b/src/redux/actions/delete-blog-action.ts
@@ -6,35 +6,35 @@ import * as ItemsRepo from '../../models/repositories/item-repository';
 import { AppState } from '../states/app-state';
 import { currenUserOronAuthStateChanged } from './user-action';
 
-export const DELETE_REQUEST = 'deleteblog/DELETE_REQUEST';
+export const DELETE_REQUEST = 'deleteblog/DELETE_REQUEST' as const;
 function deleteBlogRequest(blogURL: string) {
   return {
-    type: DELETE_REQUEST as typeof DELETE_REQUEST,
+    type: DELETE_REQUEST,
     blogURL,
   };
 }
 
-export const DELETE_RESPONSE = 'deleteblog/DELETE_RESPONSE';
+export const DELETE_RESPONSE = 'deleteblog/DELETE_RESPONSE' as const;
 function deleteBlogResponse(blogURL: string) {
   return {
-    type: DELETE_RESPONSE as typeof DELETE_RESPONSE,
+    type: DELETE_RESPONSE,
     blogURL,
   };
 }
 
-export const DELETE_ERROR = 'deleteblog/DELETE_ERROR';
+export const DELETE_ERROR = 'deleteblog/DELETE_ERROR' as const;
 function deleteBlogError(blogURL: string, error: Error) {
   return {
-    type: DELETE_ERROR as typeof DELETE_ERROR,
+    type: DELETE_ERROR,
     blogURL,
     error,
   };
 }
 
-export const RESET = 'deleteblog/RESET';
+export const RESET = 'deleteblog/RESET' as const;
 export function deleteBlogReset() {
   return {
-    type: RESET as typeof RESET,
+    type: RESET,
   };
 }
 

--- a/src/redux/actions/feed-action.ts
+++ b/src/redux/actions/feed-action.ts
@@ -11,25 +11,25 @@ import { FeedFetchHatenaStarActions } from './feed-actions/hatenastar-action';
 import { FeedFetchPocketCountActions } from './feed-actions/pocket-action';
 import { FeedFetchRSSActions } from './feed-actions/rss';
 
-export const BLOG_URL_CHANGE = 'feed/BLOG_URL_CHANGE';
+export const BLOG_URL_CHANGE = 'feed/BLOG_URL_CHANGE' as const;
 export function feedBlogURLChange(blogURL: string) {
   return {
-    type: BLOG_URL_CHANGE as typeof BLOG_URL_CHANGE,
+    type: BLOG_URL_CHANGE,
     blogURL,
   };
 }
 
-export const BLOG_URL_CLEAR = 'feed/BLOG_URL_CLEAR';
+export const BLOG_URL_CLEAR = 'feed/BLOG_URL_CLEAR' as const;
 export function feedBlogURLClear() {
   return {
-    type: BLOG_URL_CLEAR as typeof BLOG_URL_CLEAR,
+    type: BLOG_URL_CLEAR,
   };
 }
 
-export const FETCH_AND_SAVE_START = 'feed/FETCH_AND_SAVE_START';
+export const FETCH_AND_SAVE_START = 'feed/FETCH_AND_SAVE_START' as const;
 export function fetchFeed(auth: firebase.auth.Auth, blogURL: string) {
   return {
-    type: FETCH_AND_SAVE_START as typeof FETCH_AND_SAVE_START,
+    type: FETCH_AND_SAVE_START,
     auth,
     blogURL,
   };
@@ -37,10 +37,10 @@ export function fetchFeed(auth: firebase.auth.Auth, blogURL: string) {
 
 export type FeedFetchFeedAction = ReturnType<typeof fetchFeed>;
 
-export const FEED_FETCH_AND_SAVE_ERROR = 'feed/FEED_FETCH_AND_SAVE_ERROR';
+export const FEED_FETCH_AND_SAVE_ERROR = 'feed/FEED_FETCH_AND_SAVE_ERROR' as const;
 export function feedFetchAndSaveError(blogURL: string, error: Error) {
   return {
-    type: FEED_FETCH_AND_SAVE_ERROR as typeof FEED_FETCH_AND_SAVE_ERROR,
+    type: FEED_FETCH_AND_SAVE_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/count-jsoon-action.ts
+++ b/src/redux/actions/feed-actions/count-jsoon-action.ts
@@ -1,25 +1,25 @@
 import { CountResponse } from '../../../models/responses';
 
-export const FETCH_COUNT_JSOON_COUNT_REQUEST = 'feed/count.jsoon/FETCH_COUNT_REQUEST';
+export const FETCH_COUNT_JSOON_COUNT_REQUEST = 'feed/count.jsoon/FETCH_COUNT_REQUEST' as const;
 export function feedFetchCountJsoonCountRequest(blogURL: string) {
   return {
-    type: FETCH_COUNT_JSOON_COUNT_REQUEST as typeof FETCH_COUNT_JSOON_COUNT_REQUEST,
+    type: FETCH_COUNT_JSOON_COUNT_REQUEST,
     blogURL,
   };
 }
-export const FETCH_COUNT_JSOON_COUNT_RESPONSE = 'feed/count.jsoon/FETCH_COUNT_RESPONSE';
+export const FETCH_COUNT_JSOON_COUNT_RESPONSE = 'feed/count.jsoon/FETCH_COUNT_RESPONSE' as const;
 export function feedFetchCountJsoonCountResponse(blogURL: string, counts: CountResponse[]) {
   return {
-    type: FETCH_COUNT_JSOON_COUNT_RESPONSE as typeof FETCH_COUNT_JSOON_COUNT_RESPONSE,
+    type: FETCH_COUNT_JSOON_COUNT_RESPONSE,
     blogURL,
     counts,
   };
 }
 
-export const FETCH_COUNT_JSOON_COUNT_ERROR = 'feed/count.jsoon/FETCH_COUNT_ERROR';
+export const FETCH_COUNT_JSOON_COUNT_ERROR = 'feed/count.jsoon/FETCH_COUNT_ERROR' as const;
 export function feedFetchCountJsoonCountError(blogURL: string, error: Error) {
   return {
-    type: FETCH_COUNT_JSOON_COUNT_ERROR as typeof FETCH_COUNT_JSOON_COUNT_ERROR,
+    type: FETCH_COUNT_JSOON_COUNT_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/facebook-action.ts
+++ b/src/redux/actions/feed-actions/facebook-action.ts
@@ -1,25 +1,25 @@
 import { CountResponse } from '../../../models/responses';
 
-export const FETCH_FACEBOOK_COUNT_REQUEST = 'feed/facebook/FETCH_COUNT_REQUEST';
+export const FETCH_FACEBOOK_COUNT_REQUEST = 'feed/facebook/FETCH_COUNT_REQUEST' as const;
 export function feedFetchFacebookCountRequest(blogURL: string) {
   return {
-    type: FETCH_FACEBOOK_COUNT_REQUEST as typeof FETCH_FACEBOOK_COUNT_REQUEST,
+    type: FETCH_FACEBOOK_COUNT_REQUEST,
     blogURL,
   };
 }
-export const FETCH_FACEBOOK_COUNT_RESPONSE = 'feed/facebook/FETCH_COUNT_RESPONSE';
+export const FETCH_FACEBOOK_COUNT_RESPONSE = 'feed/facebook/FETCH_COUNT_RESPONSE' as const;
 export function feedFetchFacebookCountResponse(blogURL: string, counts: CountResponse[]) {
   return {
-    type: FETCH_FACEBOOK_COUNT_RESPONSE as typeof FETCH_FACEBOOK_COUNT_RESPONSE,
+    type: FETCH_FACEBOOK_COUNT_RESPONSE,
     blogURL,
     counts,
   };
 }
 
-export const FETCH_FACEBOOK_COUNT_ERROR = 'feed/facebook/FETCH_COUNT_ERROR';
+export const FETCH_FACEBOOK_COUNT_ERROR = 'feed/facebook/FETCH_COUNT_ERROR' as const;
 export function feedFetchFacebookCountError(blogURL: string, error: Error) {
   return {
-    type: FETCH_FACEBOOK_COUNT_ERROR as typeof FETCH_FACEBOOK_COUNT_ERROR,
+    type: FETCH_FACEBOOK_COUNT_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/feed-firebase-action.ts
+++ b/src/redux/actions/feed-actions/feed-firebase-action.ts
@@ -4,37 +4,37 @@ import { findBlog } from '../../../models/repositories/blog-repository';
 import { AppState } from '../../states/app-state';
 import { currenUserOronAuthStateChanged } from '../user-action';
 
-export const FIREBASE_FEED_RESPONSE = 'feed/feed/FIREBASE_RESPONSE';
+export const FIREBASE_FEED_RESPONSE = 'feed/feed/FIREBASE_RESPONSE' as const;
 export function feedFirebaseFeedItemsResponse(blogURL: string, items: ItemEntity[]) {
   return {
-    type: FIREBASE_FEED_RESPONSE as typeof FIREBASE_FEED_RESPONSE,
+    type: FIREBASE_FEED_RESPONSE,
     blogURL,
     items,
   };
 }
 
-export const FIREBASE_BLOG_REQUEST = 'feed/blog/FIREBASE_REQUEST';
+export const FIREBASE_BLOG_REQUEST = 'feed/blog/FIREBASE_REQUEST' as const;
 export function feedFirebaseBlogRequest(blogURL: string) {
   return {
-    type: FIREBASE_BLOG_REQUEST as typeof FIREBASE_BLOG_REQUEST,
+    type: FIREBASE_BLOG_REQUEST,
     blogURL,
   };
 }
 
-export const FIREBASE_BLOG_RESPONSE = 'feed/blog/FIREBASE_RESPONSE';
+export const FIREBASE_BLOG_RESPONSE = 'feed/blog/FIREBASE_RESPONSE' as const;
 export function feedFirebaseBlogResponse(blogURL: string, blogEntity: BlogEntity, user: firebase.User) {
   return {
-    type: FIREBASE_BLOG_RESPONSE as typeof FIREBASE_BLOG_RESPONSE,
+    type: FIREBASE_BLOG_RESPONSE,
     blogURL,
     blogEntity,
     user,
   };
 }
 
-export const FIREBASE_BLOG_ERROR = 'feed/blog/FIREBASE_ERROR';
+export const FIREBASE_BLOG_ERROR = 'feed/blog/FIREBASE_ERROR' as const;
 export function feedFirebaseBlogError(blogURL: string, error: Error) {
   return {
-    type: FIREBASE_BLOG_ERROR as typeof FIREBASE_BLOG_ERROR,
+    type: FIREBASE_BLOG_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/feed-firebase-save-action.ts
+++ b/src/redux/actions/feed-actions/feed-firebase-save-action.ts
@@ -1,7 +1,7 @@
 import { ItemEntity } from '../../../models/entities';
 import { CountResponse, ItemResponse } from '../../../models/responses';
 
-export const FIREBASE_SAVE_REQUEST = 'feed/FIREBASE_SAVE_REQUEST';
+export const FIREBASE_SAVE_REQUEST = 'feed/FIREBASE_SAVE_REQUEST' as const;
 
 export function feedSaveFeedRequest(
   blogURL: string,
@@ -10,7 +10,7 @@ export function feedSaveFeedRequest(
   counts: CountResponse[]
 ) {
   return {
-    type: FIREBASE_SAVE_REQUEST as typeof FIREBASE_SAVE_REQUEST,
+    type: FIREBASE_SAVE_REQUEST,
     blogURL,
     firebaseItems,
     fetchedItems,
@@ -18,20 +18,20 @@ export function feedSaveFeedRequest(
   };
 }
 
-export const FIREBASE_SAVE_RESPONSE = 'FeedSaveFeedFirebaseResponseAction';
+export const FIREBASE_SAVE_RESPONSE = 'FeedSaveFeedFirebaseResponseAction' as const;
 
 export function feedSaveFeedFirebaseResponse(blogURL: string) {
   return {
-    type: FIREBASE_SAVE_RESPONSE as typeof FIREBASE_SAVE_RESPONSE,
+    type: FIREBASE_SAVE_RESPONSE,
     blogURL,
   };
 }
 
-export const FIREBASE_SAVE_ERROR = 'FeedFirebaseSaveErrorAction';
+export const FIREBASE_SAVE_ERROR = 'FeedFirebaseSaveErrorAction' as const;
 
 export function feedFirebaseSaveError(blogURL: string, error: Error) {
   return {
-    type: FIREBASE_SAVE_ERROR as typeof FIREBASE_SAVE_ERROR,
+    type: FIREBASE_SAVE_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/hatenabookmark-action.ts
+++ b/src/redux/actions/feed-actions/hatenabookmark-action.ts
@@ -1,26 +1,26 @@
 import { CountResponse } from '../../../models/responses';
 
-export const FETCH_HATENA_BOOKMARK_COUNT_REQUEST = 'feed/hatenabookmark/FETCH_COUNT_REQUEST';
+export const FETCH_HATENA_BOOKMARK_COUNT_REQUEST = 'feed/hatenabookmark/FETCH_COUNT_REQUEST' as const;
 export function feedFetchHatenaBookmarkCountsRequest(blogURL: string) {
   return {
-    type: FETCH_HATENA_BOOKMARK_COUNT_REQUEST as typeof FETCH_HATENA_BOOKMARK_COUNT_REQUEST,
+    type: FETCH_HATENA_BOOKMARK_COUNT_REQUEST,
     blogURL,
   };
 }
 
-export const FETCH_HATENA_BOOKMARK_COUNT_RESPONSE = 'feed/hatenabookmark/FETCH_COUNNT_RESPONSE';
+export const FETCH_HATENA_BOOKMARK_COUNT_RESPONSE = 'feed/hatenabookmark/FETCH_COUNNT_RESPONSE' as const;
 export function feedFetchHatenaBookmarkCountsResponse(blogURL: string, counts: CountResponse[]) {
   return {
-    type: FETCH_HATENA_BOOKMARK_COUNT_RESPONSE as typeof FETCH_HATENA_BOOKMARK_COUNT_RESPONSE,
+    type: FETCH_HATENA_BOOKMARK_COUNT_RESPONSE,
     blogURL,
     counts,
   };
 }
 
-export const FETCH_HATENA_BOOKMARK_COUNNT_ERROR = 'feed/hatenabookmark/FETCH_COUNT_ERROR';
+export const FETCH_HATENA_BOOKMARK_COUNNT_ERROR = 'feed/hatenabookmark/FETCH_COUNT_ERROR' as const;
 export function feedFetchHatenaBookmarkCountError(blogURL: string, error: Error) {
   return {
-    type: FETCH_HATENA_BOOKMARK_COUNNT_ERROR as typeof FETCH_HATENA_BOOKMARK_COUNNT_ERROR,
+    type: FETCH_HATENA_BOOKMARK_COUNNT_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/hatenastar-action.ts
+++ b/src/redux/actions/feed-actions/hatenastar-action.ts
@@ -1,26 +1,26 @@
 import { CountResponse } from '../../../models/responses';
 
-export const FETCH_HATENA_STAR_COUNT_REQUEST = 'feed/hatenastar/FETCH_COUNT_REQUEST';
+export const FETCH_HATENA_STAR_COUNT_REQUEST = 'feed/hatenastar/FETCH_COUNT_REQUEST' as const;
 export function feedFetchHatenaStarCountsRequest(blogURL: string) {
   return {
-    type: FETCH_HATENA_STAR_COUNT_REQUEST as typeof FETCH_HATENA_STAR_COUNT_REQUEST,
+    type: FETCH_HATENA_STAR_COUNT_REQUEST,
     blogURL,
   };
 }
 
-export const FETCH_HATENA_STAR_COUNT_RESPONSE = 'feed/hatenastar/FETCH_COUNT_RESPONSE';
+export const FETCH_HATENA_STAR_COUNT_RESPONSE = 'feed/hatenastar/FETCH_COUNT_RESPONSE' as const;
 export function feedFetchHatenaStarCountsResponse(blogURL: string, counts: CountResponse[]) {
   return {
-    type: FETCH_HATENA_STAR_COUNT_RESPONSE as typeof FETCH_HATENA_STAR_COUNT_RESPONSE,
+    type: FETCH_HATENA_STAR_COUNT_RESPONSE,
     blogURL,
     counts,
   };
 }
 
-export const FETCH_HATENA_STAR_COUNT_ERROR = 'feed/hatenastar/FETCH_COUNT_ERROR';
+export const FETCH_HATENA_STAR_COUNT_ERROR = 'feed/hatenastar/FETCH_COUNT_ERROR' as const;
 export function feedFetchHatenaStarCountError(blogURL: string, error: Error) {
   return {
-    type: FETCH_HATENA_STAR_COUNT_ERROR as typeof FETCH_HATENA_STAR_COUNT_ERROR,
+    type: FETCH_HATENA_STAR_COUNT_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/pocket-action.ts
+++ b/src/redux/actions/feed-actions/pocket-action.ts
@@ -1,26 +1,26 @@
 import { CountResponse } from '../../../models/responses';
 
-export const FETCH_POCKET_COUNT_REQUEST = 'feed/pocket/FETCH_COUNT_REQUEST';
+export const FETCH_POCKET_COUNT_REQUEST = 'feed/pocket/FETCH_COUNT_REQUEST' as const;
 export function feedFetchPocketCountRequest(blogURL: string) {
   return {
-    type: FETCH_POCKET_COUNT_REQUEST as typeof FETCH_POCKET_COUNT_REQUEST,
+    type: FETCH_POCKET_COUNT_REQUEST,
     blogURL,
   };
 }
 
-export const FETCH_POCKET_COUNT_RESPONSE = 'feed/pocket/FETCH_COUNT_RESPONSE';
+export const FETCH_POCKET_COUNT_RESPONSE = 'feed/pocket/FETCH_COUNT_RESPONSE' as const;
 export function feedFetchPokcetCountResponse(blogURL: string, counts: CountResponse[]) {
   return {
-    type: FETCH_POCKET_COUNT_RESPONSE as typeof FETCH_POCKET_COUNT_RESPONSE,
+    type: FETCH_POCKET_COUNT_RESPONSE,
     blogURL,
     counts,
   };
 }
 
-export const FETCH_POCKET_COUNT_ERROR = 'feed/pocket/FETCH_COUNT_ERROR';
+export const FETCH_POCKET_COUNT_ERROR = 'feed/pocket/FETCH_COUNT_ERROR' as const;
 export function feedFetchPocketCountError(blogURL: string, error: Error) {
   return {
-    type: FETCH_POCKET_COUNT_ERROR as typeof FETCH_POCKET_COUNT_ERROR,
+    type: FETCH_POCKET_COUNT_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/feed-actions/rss.ts
+++ b/src/redux/actions/feed-actions/rss.ts
@@ -1,26 +1,26 @@
 import { ItemResponse } from '../../../models/responses';
 
-export const FETCH_RSS_REQUEST = 'feed/rss/FETCH_REQUEST';
+export const FETCH_RSS_REQUEST = 'feed/rss/FETCH_REQUEST' as const;
 export function feedFetchRSSRequest(blogURL: string) {
   return {
-    type: FETCH_RSS_REQUEST as typeof FETCH_RSS_REQUEST,
+    type: FETCH_RSS_REQUEST,
     blogURL,
   };
 }
 
-export const FETCH_RSS_RESPONSE = 'feed/rss/FETCH_RESPONSE';
+export const FETCH_RSS_RESPONSE = 'feed/rss/FETCH_RESPONSE' as const;
 export function feedFetchRSSResponse(blogURL: string, items: ItemResponse[]) {
   return {
-    type: FETCH_RSS_RESPONSE as typeof FETCH_RSS_RESPONSE,
+    type: FETCH_RSS_RESPONSE,
     blogURL,
     items,
   };
 }
 
-export const FETCH_RSS_ERROR = 'feed/rss/FETCH_ERROR';
+export const FETCH_RSS_ERROR = 'feed/rss/FETCH_ERROR' as const;
 export function feedFetchRSSError(blogURL: string, error: Error) {
   return {
-    type: FETCH_RSS_ERROR as typeof FETCH_RSS_ERROR,
+    type: FETCH_RSS_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/setting-action.ts
+++ b/src/redux/actions/setting-action.ts
@@ -4,14 +4,14 @@ import { saveBlogSetting } from '../../models/repositories/blog-repository';
 import { AppState } from '../states/app-state';
 import { currenUserOronAuthStateChanged } from './user-action';
 
-export const FIREBASE_SAVE_SETTING_REQUEST = 'setting/FIREBASE_SAVE_REQUEST';
+export const FIREBASE_SAVE_SETTING_REQUEST = 'setting/FIREBASE_SAVE_REQUEST' as const;
 export function settingSaveSettingRequest(blogURL: string) {
   return {
-    type: FIREBASE_SAVE_SETTING_REQUEST as typeof FIREBASE_SAVE_SETTING_REQUEST,
+    type: FIREBASE_SAVE_SETTING_REQUEST,
     blogURL,
   };
 }
-export const FIREBASE_SAVE_SETTING_RESPONSE = 'setting/FIREBASE_SAVE_RESPONSE';
+export const FIREBASE_SAVE_SETTING_RESPONSE = 'setting/FIREBASE_SAVE_RESPONSE' as const;
 export function settingSaveSettingResponse(
   blogURL: string,
   sendReport: boolean,
@@ -23,7 +23,7 @@ export function settingSaveSettingResponse(
   pocket: boolean
 ) {
   return {
-    type: FIREBASE_SAVE_SETTING_RESPONSE as typeof FIREBASE_SAVE_SETTING_RESPONSE,
+    type: FIREBASE_SAVE_SETTING_RESPONSE,
     blogURL,
     sendReport,
     twitter,
@@ -35,10 +35,10 @@ export function settingSaveSettingResponse(
   };
 }
 
-export const FIREBASE_SAVE_SETTING_ERROR = 'setting/FIREBASE_SAVE_ERROR';
+export const FIREBASE_SAVE_SETTING_ERROR = 'setting/FIREBASE_SAVE_ERROR' as const;
 export function settingSaveSettingError(blogURL: string, error: Error) {
   return {
-    type: FIREBASE_SAVE_SETTING_ERROR as typeof FIREBASE_SAVE_SETTING_ERROR,
+    type: FIREBASE_SAVE_SETTING_ERROR,
     blogURL,
     error,
   };

--- a/src/redux/actions/user-action.ts
+++ b/src/redux/actions/user-action.ts
@@ -3,33 +3,33 @@ import 'firebase/auth';
 import { ThunkAction } from 'redux-thunk';
 import { AppState } from '../states/app-state';
 
-export const FIREBASE_USER_REQUEST = 'user/FIREBASE_REQUEST';
+export const FIREBASE_USER_REQUEST = 'user/FIREBASE_REQUEST' as const;
 export function userFirebaseUserRequest() {
   return {
-    type: FIREBASE_USER_REQUEST as typeof FIREBASE_USER_REQUEST,
+    type: FIREBASE_USER_REQUEST,
   };
 }
 
-export const FIREBASE_USER_RESPONSE = 'user/FIREBASE_RESPONSE';
+export const FIREBASE_USER_RESPONSE = 'user/FIREBASE_RESPONSE' as const;
 export function userFirebaseUserResponse(user: firebase.User) {
   return {
-    type: FIREBASE_USER_RESPONSE as typeof FIREBASE_USER_RESPONSE,
+    type: FIREBASE_USER_RESPONSE,
     user,
   };
 }
 export type UserFirebaseUserResponseAction = ReturnType<typeof userFirebaseUserResponse>;
 
-export const FIREBASE_USER_UNAUTHORIZED_ERROR = 'user/FIREBASE_UNAUTHORIZED_ERROR';
+export const FIREBASE_USER_UNAUTHORIZED_ERROR = 'user/FIREBASE_UNAUTHORIZED_ERROR' as const;
 function userFirebaseUserUnauthorizedError() {
   return {
-    type: FIREBASE_USER_UNAUTHORIZED_ERROR as typeof FIREBASE_USER_UNAUTHORIZED_ERROR,
+    type: FIREBASE_USER_UNAUTHORIZED_ERROR,
   };
 }
 
-export const FIREBASE_USER_ERROR = 'user/FIREBASE_ERROR';
+export const FIREBASE_USER_ERROR = 'user/FIREBASE_ERROR' as const;
 export function userFirebaseUserError(error: Error) {
   return {
-    type: FIREBASE_USER_ERROR as typeof FIREBASE_USER_ERROR,
+    type: FIREBASE_USER_ERROR,
     error,
   };
 }
@@ -40,24 +40,24 @@ export type UserFetchActions =
   | ReturnType<typeof userFirebaseUserError>
   | ReturnType<typeof userFirebaseUserUnauthorizedError>;
 
-export const FIREBASE_SIGNOUT_REQUEST = 'user/signout/FIREBASE_REQUEST';
+export const FIREBASE_SIGNOUT_REQUEST = 'user/signout/FIREBASE_REQUEST' as const;
 function userFirebaseSignoutRequest() {
   return {
-    type: FIREBASE_SIGNOUT_REQUEST as typeof FIREBASE_SIGNOUT_REQUEST,
+    type: FIREBASE_SIGNOUT_REQUEST,
   };
 }
 
-export const FIREBASE_SIGNOUT_RESPONSE = 'user/signout/FIREBASE_RESPONSE';
+export const FIREBASE_SIGNOUT_RESPONSE = 'user/signout/FIREBASE_RESPONSE' as const;
 export function userFirebaseSignoutResponse() {
   return {
-    type: FIREBASE_SIGNOUT_RESPONSE as typeof FIREBASE_SIGNOUT_RESPONSE,
+    type: FIREBASE_SIGNOUT_RESPONSE,
   };
 }
 
-export const FIREBASE_SIGNOUT_ERROR = 'user/signout/FIREBASE_ERROR';
+export const FIREBASE_SIGNOUT_ERROR = 'user/signout/FIREBASE_ERROR' as const;
 export function userFirebaseSignoutError(error: Error) {
   return {
-    type: FIREBASE_SIGNOUT_ERROR as typeof FIREBASE_SIGNOUT_ERROR,
+    type: FIREBASE_SIGNOUT_ERROR,
     error,
   };
 }


### PR DESCRIPTION
TypeScript introduced "as const" from v3.4. 