### PR TITLE
Fix the feed page doesn't match normalized blog URLs on production

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,17 +32,17 @@ const App = () => (
         <Router>
           <ScrollToTop>
             <Switch>
-              <Route exact={true} path="/" component={withTracker(IndexPage)} />
-              <Route exact={true} path="/signin" component={withTracker(SignInPage)} />
-              <Route exact={true} path="/term" component={withTracker(TermPage)} />
-              <Route exact={true} path="/privacy" component={withTracker(PrivacyPage)} />
+              <Route exact path="/" component={withTracker(IndexPage)} />
+              <Route exact path="/signin" component={withTracker(SignInPage)} />
+              <Route exact path="/term" component={withTracker(TermPage)} />
+              <Route exact path="/privacy" component={withTracker(PrivacyPage)} />
               <AuthPage>
                 <Switch>
-                  <Route exact={true} path="/add" component={withTracker(AddBlogPage)} />
-                  <Route exact={true} path="/blogs" component={withTracker(BlogsPage)} />
-                  <Route exact={true} path="/blogs/:blogURL" component={withTracker(FeedPage)} />
-                  <Route exact={true} path="/settings" component={withTracker(SettingsPage)} />
-                  <Route exact={true} path="/settings/:blogURL" component={withTracker(SettingPage)} />
+                  <Route exact path="/add" component={withTracker(AddBlogPage)} />
+                  <Route exact path="/blogs" component={withTracker(BlogsPage)} />
+                  <Route path="/blogs/:blogURL" component={withTracker(FeedPage)} />
+                  <Route exact path="/settings" component={withTracker(SettingsPage)} />
+                  <Route path="/settings/:blogURL" component={withTracker(SettingPage)} />
                 </Switch>
               </AuthPage>
             </Switch>

--- a/src/components/pages/FeedPage/index.tsx
+++ b/src/components/pages/FeedPage/index.tsx
@@ -20,7 +20,15 @@ type CountMap = Map<string, number>;
 type AnimateMap = Map<string, boolean>;
 
 const FeedPage: React.FC<RouteComponentProps<{ blogURL: string }>> = (props) => {
-  const blogURL = decodeURIComponent(props.match.params.blogURL);
+  let blogURL = decodeURIComponent(props.match.params.blogURL);
+
+  if (!blogURL?.startsWith('http://') && !blogURL?.startsWith('https://')) {
+    const matched = /^\/blogs\/(.+)$/.exec(props.location.pathname)?.[1];
+    if (matched) {
+      blogURL = matched;
+    }
+  }
+
   const feed = useSelector<AppState, FeedState>((state) => state.feeds.feeds[blogURL]);
   const dispatch = useDispatch();
 

--- a/src/components/pages/FeedPage/index.tsx
+++ b/src/components/pages/FeedPage/index.tsx
@@ -21,7 +21,9 @@ type AnimateMap = Map<string, boolean>;
 
 const FeedPage: React.FC<RouteComponentProps<{ blogURL: string }>> = (props) => {
   let blogURL = decodeURIComponent(props.match.params.blogURL);
-
+  // On production, web browsers normalize the blog URLs without encoding.
+  // The URLs don't match React Router's path matching rules.
+  // So, the following code extracts the blog URL from `location`.
   if (!blogURL?.startsWith('http://') && !blogURL?.startsWith('https://')) {
     const matched = /^\/blogs\/(.+)$/.exec(props.location.pathname)?.[1];
     if (matched) {

--- a/src/components/pages/SettingPage/index.tsx
+++ b/src/components/pages/SettingPage/index.tsx
@@ -31,7 +31,7 @@ type Props = RouteComponentProps<{ blogURL: string }>;
 const SettingPage: React.FC<Props> = (props) => {
   let blogURL = decodeURIComponent(props.match.params.blogURL);
   // On production, web browsers normalize the blog URLs without encoding.
-  // The URLs don't match to React Router's path matching rules.
+  // The URLs don't match React Router's path matching rules.
   // So, the following code extracts the blog URL from `location`.
   if (!blogURL?.startsWith('http://') && !blogURL?.startsWith('https://')) {
     const matched = /^\/blogs\/(.+)$/.exec(props.location.pathname)?.[1];

--- a/src/components/pages/SettingPage/index.tsx
+++ b/src/components/pages/SettingPage/index.tsx
@@ -29,7 +29,16 @@ import { SettingState, saveSetting, sendTestReportMail } from '../../../redux/sl
 type Props = RouteComponentProps<{ blogURL: string }>;
 
 const SettingPage: React.FC<Props> = (props) => {
-  const blogURL = decodeURIComponent(props.match.params.blogURL);
+  let blogURL = decodeURIComponent(props.match.params.blogURL);
+  // On production, web browsers normalize the blog URLs without encoding.
+  // The URLs don't match to React Router's path matching rules.
+  // So, the following code extracts the blog URL from `location`.
+  if (!blogURL?.startsWith('http://') && !blogURL?.startsWith('https://')) {
+    const matched = /^\/blogs\/(.+)$/.exec(props.location.pathname)?.[1];
+    if (matched) {
+      blogURL = matched;
+    }
+  }
 
   const userState = useSelector<AppState, UserState>((state) => state.user);
   const feedState = useSelector<AppState, FeedState>((state) => state.feeds.feeds[blogURL]);


### PR DESCRIPTION
On production, web browsers normalize the blog URLs without encoding. The URLs don't match React Router's path rules. So, I added code that extracts the blog URL from `location`.